### PR TITLE
Found a workaround for the CryptoStream that cannot be seeked

### DIFF
--- a/Player/vlcplayerCsharp1/Form1.cs
+++ b/Player/vlcplayerCsharp1/Form1.cs
@@ -1,14 +1,8 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Data;
-using System.Drawing;
 using System.IO;
-using System.Linq;
 using System.Reflection;
 using System.Security.Cryptography;
 using System.Text;
-using System.Threading.Tasks;
 using System.Windows.Forms;
 
 namespace vlcplayerCsharp1
@@ -40,19 +34,21 @@ namespace vlcplayerCsharp1
         {
             // read file path from TextBox3.Text
             var FileStream = new FileStream(path: TextBox3.Text, mode: FileMode.Open, access: FileAccess.Read);
-            RijndaelManaged AES = new RijndaelManaged();
-            SHA256Cng SHA256 = new SHA256Cng();
-
-            // read key from TextBox4.Text
-            AES.Key = SHA256.ComputeHash(Encoding.ASCII.GetBytes(TextBox4.Text));
-            AES.Mode = CipherMode.ECB;
 
 
-            // cryptostream starts here
-            var cryptoStream = new CryptoStream(FileStream, AES.CreateDecryptor(), CryptoStreamMode.Read);
+            var streamWrapper = new SeekableStreamWrapper(() =>
+            {
+                FileStream.Seek(0, SeekOrigin.Begin);
+                RijndaelManaged AES = new RijndaelManaged();
+                SHA256Cng SHA256 = new SHA256Cng();
 
-            // reading decrypted cryptostream and saves into video.mp4
-           VlcControl1.Play(cryptoStream);
+                // read key from TextBox4.Text
+                AES.Key = SHA256.ComputeHash(Encoding.ASCII.GetBytes(TextBox4.Text));
+                AES.Mode = CipherMode.ECB;
+                return new CryptoStream(FileStream, AES.CreateDecryptor(), CryptoStreamMode.Read, true);
+            });
+
+            VlcControl1.Play(streamWrapper);
         }
 
         private void Button4_Click(object sender, EventArgs e)

--- a/Player/vlcplayerCsharp1/SeekableStreamWrapper.cs
+++ b/Player/vlcplayerCsharp1/SeekableStreamWrapper.cs
@@ -1,0 +1,103 @@
+﻿using System;
+using System.IO;
+
+namespace vlcplayerCsharp1
+{
+
+    /// <summary>
+    /// A wrapper that destroys and creates a stream on demand to be able to seek into non-seekable stream...
+    /// </summary>
+    public class SeekableStreamWrapper : Stream
+    {
+        private readonly Func<Stream> _createStream;
+        private Stream _innerStream;
+        private long _position = 0;
+
+        /// <summary>
+        /// The constructor
+        /// </summary>
+        /// <param name="createStream"></param>
+        public SeekableStreamWrapper(Func<Stream> createStream)
+        {
+            this._createStream = createStream;
+            this._innerStream = createStream();
+        }
+
+        public override bool CanRead => true;
+
+        public override bool CanSeek => true;
+
+        public override bool CanWrite => false;
+
+        public override long Length => this._innerStream.Length;
+
+        public override long Position { get => this._position; set => this.Seek(value, SeekOrigin.Begin); }
+
+        public override void Flush() => this._innerStream.Flush();
+
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            var read = this._innerStream.Read(buffer, offset, count);
+            this._position += read;
+            return read;
+        }
+
+
+        public override long Seek(long offset, SeekOrigin origin)
+        {
+            if (origin != SeekOrigin.Begin)
+            {
+                throw new NotSupportedException("Only supports seeking from the beginning");
+            }
+
+            long remaining = 0;
+            if (offset > this._position)
+            {
+                remaining = offset - this._position;
+            }
+            else
+            {
+                try
+                {
+                    this._innerStream.Dispose();
+                }
+                catch (Exception)
+                {
+                    // Shit happens... On .NET framework, calling Dispose() on a crypto stream without having read anything can throw...
+                }
+                this._innerStream = this._createStream();
+                remaining = offset;
+            }
+
+            var buffer = new byte[Math.Min(0x100_000, remaining)];
+            while (remaining > 0)
+            {
+                var read = this._innerStream.Read(buffer, 0, Math.Min(0x100_000, (remaining > int.MaxValue) ? int.MaxValue : (int)remaining));
+                remaining -= read;
+            }
+
+            this._position = offset;
+            return offset;
+        }
+
+        public override void SetLength(long value)
+        {
+            throw new NotSupportedException();
+        }
+
+        public override void Write(byte[] buffer, int offset, int count)
+        {
+            throw new NotSupportedException();
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                this._innerStream.Dispose();
+            }
+
+            base.Dispose(disposing);
+        }
+    }
+}

--- a/Player/vlcplayerCsharp1/vlcplayerCsharp1.csproj
+++ b/Player/vlcplayerCsharp1/vlcplayerCsharp1.csproj
@@ -73,6 +73,7 @@
     </Compile>
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="SeekableStreamWrapper.cs" />
     <EmbeddedResource Include="Form1.resx">
       <DependentUpon>Form1.cs</DependentUpon>
     </EmbeddedResource>


### PR DESCRIPTION
It does throw an exception on `this._innerStream.Length`, but you can safely ignore this, unless you want to seek into the file. In that case, you will have to read the stream once to get its length.